### PR TITLE
[Add]エネミーの移動とエネミーの種類ごとの移動方向を設定

### DIFF
--- a/Assets/Hidaka/EnemyMove.cs
+++ b/Assets/Hidaka/EnemyMove.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+/// <summary>
+///エネミー移動
+/// </summary>
+public class EnemyMove : MonoBehaviour
+{
+    /// <summary>
+    /// エネミーのスピード
+    /// </summary>
+    [Tooltip("エネミーにアタッチする"), SerializeField] private float _speed = 2.0f;
+
+    /// <summary>エネミーの軸移動方向</summary>
+    private int x = 0;
+
+    private void Start()
+    {
+        GetComponent<Transform>().position = this.gameObject.transform.position;
+    }
+
+    /// <summary>
+    /// エネミーの移動
+    /// </summary>
+    void Update()
+    {
+        if(this.gameObject.name == "dog") x += 1;//背景スピード*方向
+        else  x-= 1;
+        transform.Translate(x, 0, 0);
+
+        if (x <= 30 || x >= -30)
+        {
+            Destroy(this.gameObject);
+        }
+    }
+}

--- a/Assets/Hidaka/EnemyMove.cs.meta
+++ b/Assets/Hidaka/EnemyMove.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f333bb6120ebbb48bf75ae54e03a4b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
壁が移動するとのことで、通常エネミーは壁の移動と同じ速度での移動。
犬の場合はプレイヤーを覆いかけるため壁の移動方向とは逆方向に移動。
現時点で書けているのは一直線での移動のみです。