### PR TITLE
定数ファイルを作成、scene名を一括管理できるようにした

### DIFF
--- a/Assets/Dev_βType/GameScene_β.unity
+++ b/Assets/Dev_βType/GameScene_β.unity
@@ -197,6 +197,8 @@ MonoBehaviour:
   _centerPos: {fileID: 611450220}
   EndPos: {fileID: 992709109}
   _moveSpeed: 5
+  _obon: {fileID: 0}
+  i: 0
   isPhonDebug: 0
 --- !u!1 &99355594
 GameObject:
@@ -558,13 +560,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4c2b0e8532bd8b145a93e78a7524415f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _playerSpeed: 3
+  _stickYNum: 0
   _gyroTime: 1
   _raneNum:
   - {fileID: 567172685}
   - {fileID: 839821487}
   - {fileID: 391709730}
-  _flickValue: 70
 --- !u!212 &180136893
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -704,8 +705,8 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 437643865}
         m_TargetAssemblyTypeName: AttachedSceneController, Assembly-CSharp
-        m_MethodName: ChangeScene
-        m_Mode: 5
+        m_MethodName: ChangeTitleScene
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/Ueno/Scene/HomeScene.unity
+++ b/Assets/Ueno/Scene/HomeScene.unity
@@ -367,14 +367,14 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 953875540}
         m_TargetAssemblyTypeName: AttachedSceneController, Assembly-CSharp
-        m_MethodName: ChangeScene
-        m_Mode: 5
+        m_MethodName: ChangeGameScene
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: GameScene_Proto
+          m_StringArgument: "GameScene_\u03B2"
           m_BoolArgument: 0
         m_CallState: 2
 --- !u!114 &49372717
@@ -3611,7 +3611,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1707403051
 RectTransform:
   m_ObjectHideFlags: 0
@@ -4000,9 +4000,9 @@ RectTransform:
   m_Father: {fileID: 316568271}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1056, y: -462.37842}
   m_SizeDelta: {x: 300, y: 300}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1790065118
@@ -4183,9 +4183,9 @@ RectTransform:
   m_Father: {fileID: 316568271}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 352, y: -462.37842}
   m_SizeDelta: {x: 300, y: 300}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1842144441
@@ -4787,9 +4787,9 @@ RectTransform:
   m_Father: {fileID: 316568271}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1760, y: -462.37842}
   m_SizeDelta: {x: 300, y: 300}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2072011416

--- a/Assets/Ueno/Scene/TitleScene.unity
+++ b/Assets/Ueno/Scene/TitleScene.unity
@@ -877,8 +877,8 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 337094629}
         m_TargetAssemblyTypeName: AttachedSceneController, Assembly-CSharp
-        m_MethodName: ChangeScene
-        m_Mode: 5
+        m_MethodName: ChangeHomeScene
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/Ueno/SceneManager/AttachedSceneController.cs
+++ b/Assets/Ueno/SceneManager/AttachedSceneController.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Common;
 
 /// <summary>
 ///ÉVÅ[ÉìëJà⁄ 
@@ -12,6 +13,23 @@ public class AttachedSceneController : MonoBehaviour
     public void ChangeScene(string target)
     {
         SceneChangeScript.LoadScene(target);
+    }
+
+    public void ChangeTitleScene()
+    {
+        SceneChangeScript.LoadScene(Define.SCENENAME_TITLE);
+    }
+    public void ChangeHomeScene()
+    {
+        SceneChangeScript.LoadScene(Define.SCENENAME_HOME);
+    }
+    public void ChangeGameScene()
+    {
+        SceneChangeScript.LoadScene(Define.SCENENAME_MASTERGAME);
+    }
+    public void ChangeResultScene()
+    {
+        SceneChangeScript.LoadScene(Define.SCENENAME_RESULT);
     }
 
     public void Finish()

--- a/Assets/Ueno/Script/Constants.cs
+++ b/Assets/Ueno/Script/Constants.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+using System.Collections;
+
+namespace Common
+{
+    public static class Define
+    {
+        public const string SCENENAME_TITLE = "TitleScene";
+        public const string SCENENAME_HOME = "HomeScene";
+        public const string SCENENAME_MASTERGAME = "GameScene_É¿";
+        public const string SCENENAME_RESULT = "ResultScene";
+    }
+}

--- a/Assets/Ueno/Script/Constants.cs.meta
+++ b/Assets/Ueno/Script/Constants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 997099fa72206974ab967fbac6b8fb3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Sceneの名前を直接Inspectorから入力していたが、名称を定数化に変え、変更を一括で行い易くした。